### PR TITLE
Fixed setupscript

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ exec(open('treeomics/version.py').read())
 
 setup(
       name='treeomics',                                  # package name
-      # packages=find_packages(),
-      packages=['treeomics', 'tests'],  # 'treeomics.phylogeny', 'treeomics.plots', 'treeomics.utils'],
+      packages=setuptools.find_packages(),
+      #packages=['treeomics', 'tests'],  # 'treeomics.phylogeny', 'treeomics.plots', 'treeomics.utils'],
       version=__version__,
       description='Treeomics infers metastatic seeding patterns from DNA sequencing data.',
       install_requires=['numpy', 'scipy', 'pandas', 'matplotlib', 'seaborn', 'networkx<2.0',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup
+import setuptools
 
 
 __version__ = 'unknown'
 exec(open('treeomics/version.py').read())
 
-setup(
+setuptools.setup(
       name='treeomics',                                  # package name
       packages=setuptools.find_packages(),
       #packages=['treeomics', 'tests'],  # 'treeomics.phylogeny', 'treeomics.plots', 'treeomics.utils'],

--- a/treeomics/__main__.py
+++ b/treeomics/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """Main file to run Treeomics and infer metastatic seeding patterns"""
 import logging
 import sys


### PR DESCRIPTION
Fixed `setup.py`. `treeomics` is now installed with its submodules.

Also removed shebang. When installed with `pip`, the setuptools create their own shebang pointing to the associated python binary.